### PR TITLE
Pass config into instance

### DIFF
--- a/src/angular-swing.js
+++ b/src/angular-swing.js
@@ -6,10 +6,10 @@ angular
         return {
             restrict: 'A',
             scope: {},
-            controller: function () {
+            controller: function ($scope) {
                 var stack;
 
-                stack = Swing.Stack();
+                stack = Swing.Stack($scope.$parent.swingStackConfig);
 
                 this.add = function (cardElement) {
                     return stack.createCard(cardElement);


### PR DESCRIPTION
Allows a config object to be passed into the underlying Swing.Stack() instance. I've only tested it with the following:

```Javascript
  $scope.swingStackConfig = {
    maxRotation: 1
  };
```