### PR TITLE
Adds support for custom isThrowOut() and throwOutConfidence() functions

### DIFF
--- a/src/angular-swing.js
+++ b/src/angular-swing.js
@@ -5,11 +5,28 @@ angular
     .directive('swingStack', function () {
         return {
             restrict: 'A',
-            scope: {},
-            controller: function () {
+            scope: {
+              isThrowOut: '&',
+              throwOutConfidence: '&'
+            },
+            controller: function ($scope) {
                 var stack;
 
-                stack = Swing.Stack();
+                var config = { };
+
+                if ($scope.isThrowOut) {
+                  config.isThrowOut = function (offset, elementWidth) {
+                    return $scope.isThrowOut({ offset: offset, elementWidth: elementWidth });
+                  }
+                }
+
+                if ($scope.throwOutConfidence) {
+                  config.throwOutConfidence = function (offset, elementWidth) {
+                    return $scope.throwOutConfidence({ offset: offset, elementWidth: elementWidth });
+                  }
+                }
+
+                stack = Swing.Stack(config);
 
                 this.add = function (cardElement) {
                     return stack.createCard(cardElement);


### PR DESCRIPTION
*Uses HTML like:*
          `<ul swing-stack
              is-throw-out="isThrowOut(offset, elementWidth)"
              throw-out-confidence="throwOutConfidence(offset, elementWidth)">`

*And a controller like:*
  `$scope.isThrowOut = function (offset, elementWidth) {
    return $scope.throwOutConfidence(offset, elementWidth) == 1;
  };`

 `$scope.throwOutConfidence = function (offset, elementWidth) {
    return Math.min(Math.abs(offset) / 30, 1);
  };`

Note we generally only need to override throwOutConfidence, and don't need to override the default isThrowOut() function. Except there's a bug in that the default isThrowOut() function isn't calling the config version of throwOutConfidence - it's hard coded to call the internal Card.throwOutConfidence().

*This:*
`Card.isThrowOut = function (offset, elementWidth) {
    return Card.throwOutConfidence(offset, elementWidth) == 1;
};`

*Should be this:*
`Card.isThrowOut = function (offset, elementWidth) {
    // this refers to our config object
    return this.throwOutConfidence(offset, elementWidth) == 1;
};`
However I'm not exactly sure how to update both swing and angular-swing to make that change. Doesn't look like angular-swing has been rebuilt to the latest version of swing.
